### PR TITLE
fix(handler-abort): handle when fetchOptions is undefined

### DIFF
--- a/packages/handle-abort/src/lib/createAbortLink.spec.ts
+++ b/packages/handle-abort/src/lib/createAbortLink.spec.ts
@@ -61,4 +61,35 @@ describe('createAbortLink', () => {
 
     expect(onAbort).toBeCalled();
   });
+
+  it('should handle no fetchOptions', async () => {
+    const onAbort = jest.fn();
+    const abortLink = createAbortLink({ onAbort });
+
+    await testApolloLink(abortLink, () => ({
+      operationName: OPERATION_NAME,
+      context: {},
+    }));
+
+    expect(onAbort).not.toBeCalled();
+  });
+
+  it('should not be called when an error occurs', async () => {
+    const onAbort = jest.fn();
+    const errorLink = createAbortLink({ onAbort });
+
+    const throwLink = new ApolloLink((operation, forward) => {
+      return forward(operation).map(() => {
+        throw new Error();
+      });
+    });
+
+    await expect(async () => {
+      await testApolloLink(ApolloLink.from([errorLink, throwLink]), () => ({
+        operationName: OPERATION_NAME,
+      }));
+    }).rejects.toThrow();
+
+    expect(onAbort).not.toBeCalled();
+  });
 });

--- a/packages/handle-abort/src/lib/createAbortLink.ts
+++ b/packages/handle-abort/src/lib/createAbortLink.ts
@@ -12,7 +12,8 @@ export const createAbortLink = ({
 }: CreateAbortLinkOptions = {}) => {
   const requestHandler = new ApolloLink((operation, forward) => {
     const context = operation.getContext();
-    const signal: AbortSignal | undefined = context['fetchOptions'].signal;
+    const { fetchOptions = {} } = context;
+    const signal: AbortSignal | undefined = fetchOptions.signal;
 
     if (signal) {
       const abortHandler = createAbortEventListener(operation);
@@ -31,8 +32,9 @@ export const createAbortLink = ({
 
   const responseHandler = (operation: Operation) => {
     const context = operation.getContext();
+    const { fetchOptions = {} } = context;
 
-    const signal: AbortSignal | undefined = context['fetchOptions'].signal;
+    const signal: AbortSignal | undefined = fetchOptions.signal;
     const abortHandler = context['abortHandler'];
 
     if (signal && abortHandler) {


### PR DESCRIPTION
## Problem definition

When `fetchOptions` is not passed in the context, the application throws an error unable to handle the apollo link.

## Solution specification

Allow `fetchOptions` to be undefined without throwing an error.